### PR TITLE
Use https link for pi-hole installation script

### DIFF
--- a/roles/pi/tasks/main.yml
+++ b/roles/pi/tasks/main.yml
@@ -56,7 +56,7 @@
 
 - name: "Download Pi-Hole installer"
   get_url:
-      url: http://install.pi-hole.net
+      url: https://install.pi-hole.net
       dest: ~/install-pihole.sh
       mode: 0740
   tags: pihole


### PR DESCRIPTION
Adds a little more security